### PR TITLE
Update workshop schedule with new timing and sessions

### DIFF
--- a/pages/schedule.mdx
+++ b/pages/schedule.mdx
@@ -4,14 +4,12 @@
 
 Location: [Rangos Ballroom 2, Cohon University Center](https://www.cmu.edu/cohon-university-center/images/floor-plans/CUC_2.pdf)
 
-- _9:00 - 9:30_: Opening Remarks - Graham Neubig (CMU)
-- _9:30 - 10:15_: Invited Talk - Akari Asai (CMU)
-- _10:15 - 10:30_: Break
-- _10:30 - 11:15_: Invited Talk - Gabe Gomes (CMU)
-- _11:15 - 12:00_: Invited Talk - Chenglei Si (Stanford)
-- _12:00 - 13:30_: Lunch Break
-- _13:30 - 14:15_: Invited Talk - Keyon Vafa (Harvard)
-- _14:15 - 16:00_: [Poster Session](/posters)
-- _16:00 - 17:00_: Panel Discussion: The Future of AI in Scientific Discovery
-- _17:00 - 17:30_: Closing Remarks
+- _10:00 - 10:15_: Opening
+- _10:15 - 11:00_: Invited Talk - Chenglei Si (Stanford)
+- _11:00 - 11:45_: Invited Talk - Gabe Gomes (CMU)
+- _11:45 - 13:00_: Lunch + Poster Session
+- _13:00 - 13:45_: Invited Talk - Akari Asai (CMU)
+- _13:45 - 14:30_: Invited Talk - Keyon Vafa (Harvard)
+- _14:30 - 16:00_: Breakout Session (Lab Visit, Hands-on Sessions on Research Automation, AI Surveys, etc.)
+- _16:00 - 17:00_: Group Discussion and Closing
 


### PR DESCRIPTION
This PR updates the workshop schedule with the new timing and sessions as requested:

- Changed the start time to 10:00 AM
- Updated the order of invited talks (Chenglei Si, Gabe Gomes, Akari Asai, Keyon Vafa)
- Combined lunch and poster session from 11:45 AM to 1:00 PM
- Added breakout session from 2:30 PM to 4:00 PM for lab visits and hands-on sessions
- Updated the closing session from 4:00 PM to 5:00 PM

All speakers have confirmed their participation as noted in the conversation.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/184292487ffa466d89c3bf63b37ddcb0)