### PR TITLE
Update workshop location from Rangos Ballroom 2 to Room CUC-MPW

### DIFF
--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -15,7 +15,7 @@ You are invited to join a one-day workshop on AI for Science, exploring the inte
 
 ## Important Info
 - __Time__: September 12, 2025, see [schedule](/schedule)
-- __Location__: [Rangos Ballroom 2, Cohon University Center](https://www.cmu.edu/cohon-university-center/images/floor-plans/CUC_2.pdf)
+- __Location__: [Room CUC-MPW, Cohon University Center](https://www.cmu.edu/cohon-university-center/images/floor-plans/CUC_2.pdf)
 - 🚀 __Call for Posters__: Calling all researchers to share their projects about AI for scientific discovery. More information: [posters](/posters)
 - If you are interested in participating, please fill out the form https://forms.gle/3EDPBYCEUv4dzuzm8. We will send you more information about the workshop as it becomes available.
 

--- a/pages/schedule.mdx
+++ b/pages/schedule.mdx
@@ -2,7 +2,7 @@
 
 ### Friday, September 12, 2025
 
-Location: [Rangos Ballroom 2, Cohon University Center](https://www.cmu.edu/cohon-university-center/images/floor-plans/CUC_2.pdf)
+Location: [Room CUC-MPW, Cohon University Center](https://www.cmu.edu/cohon-university-center/images/floor-plans/CUC_2.pdf)
 
 - _10:00 - 10:15_: Opening
 - _10:15 - 11:00_: Invited Talk - Chenglei Si (Stanford)

--- a/public/banner.svg
+++ b/public/banner.svg
@@ -89,7 +89,7 @@
   
   <!-- Location with refined styling -->
   <text x="400" y="185" font-family="system-ui, -apple-system, sans-serif" font-size="16" font-weight="400" text-anchor="middle" fill="rgba(255,255,255,0.85)">
-    Rangos Ballroom 2, Cohon University Center
+    Room CUC-MPW, Cohon University Center
   </text>
   
   <!-- Tagline with elegant typography -->


### PR DESCRIPTION
This PR updates the workshop location information across all places in the website, including the banner image.

## Changes Made:
- ✅ Updated location in homepage (`pages/index.mdx`) - Important Info section
- ✅ Updated location in schedule page (`pages/schedule.mdx`) 
- ✅ Updated location in banner image (`public/banner.svg`)

## Before:
- Location: Rangos Ballroom 2, Cohon University Center

## After:
- Location: Room CUC-MPW, Cohon University Center

All references now correctly show the updated venue information. The website has been tested and builds successfully with these changes.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/bde6a0cca0ad481893f8ea47a772d6fd)