### PR TITLE
Update registration forms and poster deadline

### DIFF
--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -11,13 +11,13 @@ import magarac_logo from '../public/2025_sponsors/magarac.png';
 
 <Image src={cover} alt="Banner Image for the workshop highlighting the dates and venue."/>
  
-You are invited to join a one-day workshop on AI for Science, exploring the intersection of artificial intelligence and scientific discovery. [Sign up to participate!](https://forms.gle/3EDPBYCEUv4dzuzm8)
+You are invited to join a one-day workshop on AI for Science, exploring the intersection of artificial intelligence and scientific discovery. [Sign up to participate!](https://forms.gle/NY3XWNWJF6zucvfr5)
 
 ## Important Info
 - __Time__: September 12, 2025, see [schedule](/schedule)
 - __Location__: [Rangos Ballroom 2, Cohon University Center](https://www.cmu.edu/cohon-university-center/images/floor-plans/CUC_2.pdf)
 - 🚀 __Call for Posters__: Calling all researchers to share their projects about AI for scientific discovery. More information: [posters](/posters)
-- If you are interested in participating, please fill out the form https://forms.gle/3EDPBYCEUv4dzuzm8. We will send you more information about the workshop as it becomes available.
+- If you are interested in participating, please fill out the form https://forms.gle/NY3XWNWJF6zucvfr5. We will send you more information about the workshop as it becomes available.
 
 ## Topics of Interest
 Some of the topics that you might be interested in that may appear in the workshop (definitely not an exhaustive list):

--- a/pages/posters.mdx
+++ b/pages/posters.mdx
@@ -2,14 +2,16 @@
 
 We invite researchers to submit posters related to AI for Science. This is a great opportunity to showcase your work on AI applications in scientific discovery, machine learning for scientific data analysis, and other related topics.
 
-#### Submission Deadline: August 15, 2025
+**[Submit your poster here!](https://forms.gle/VYeiDQ4URbRqecQj8)**
+
+#### Submission Deadline: September 5, 2025
 
 ### Submission Guidelines
 
 - Submissions should be related to AI applications in scientific domains
 - Submit a 2-page extended abstract in PDF format
 - Include title, authors, affiliations, and a brief description of your work
-- Email your submission to cmu-ai-for-science-workshop@andrew.cmu.edu with the subject line "Poster Submission"
+- Use the [poster submission form](https://forms.gle/VYeiDQ4URbRqecQj8) to submit your poster
 
 ### Topics of Interest
 


### PR DESCRIPTION
This PR updates the website with the new Google Forms and adjusts the poster submission deadline as requested.

## Changes Made

### Registration Form Updates
- ✅ Updated registration form links on the main page from the old URL to the new Google Form: https://forms.gle/NY3XWNWJF6zucvfr5
- ✅ Updated both instances of the registration form link (in the intro paragraph and Important Info section)

### Poster Form Integration
- ✅ Added a prominent "Submit your poster here!" link on the posters page pointing to: https://forms.gle/VYeiDQ4URbRqecQj8
- ✅ Updated submission guidelines to reference the poster submission form instead of email submission

### Deadline Update
- ✅ Changed poster submission deadline from August 15, 2025 to September 5, 2025

## Files Modified
- `pages/index.mdx` - Updated registration form links
- `pages/posters.mdx` - Added poster form link, updated deadline, and modified submission guidelines

The website now properly integrates both Google Forms and reflects the updated poster submission deadline.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/9720b0648f694ded8553a0f6c4b5a677)