### PR TITLE
Add Biomedical Discovery Panel to Workshop Schedule

### DIFF
--- a/pages/schedule.mdx
+++ b/pages/schedule.mdx
@@ -10,11 +10,11 @@ Location: [Room CUC-MPW, Cohon University Center](https://www.cmu.edu/cohon-univ
 - _11:45 - 13:00_: Lunch + Poster Session
 - _13:00 - 13:45_: Invited Talk - Akari Asai (CMU)
 - _13:45 - 14:30_: Invited Talk - Keyon Vafa (Harvard)
-- _15:30 - 16:30_: Breakout Sessions:
+- _14:30 - 16:30_: Breakout Sessions:
   - **Discussion: Autonomous Systems for Science**
   - **Discussion: Building Scientific Foundation Models**
-  - **Discussion: Panel on Biomedical Discovery** (Room CUC Dowd)
   - **Hands-on: Visit an Autonomous Lab**
+- _15:30 - 16:30_: **Discussion: Panel on Biomedical Discovery** (Room CUC Dowd)
 - _16:30 - 17:00_: Group Discussion and Closing
 
 ## Breakout Session Details

--- a/pages/schedule.mdx
+++ b/pages/schedule.mdx
@@ -10,7 +10,7 @@ Location: [Room CUC-MPW, Cohon University Center](https://www.cmu.edu/cohon-univ
 - _11:45 - 13:00_: Lunch + Poster Session
 - _13:00 - 13:45_: Invited Talk - Akari Asai (CMU)
 - _13:45 - 14:30_: Invited Talk - Keyon Vafa (Harvard)
-- _15:30 - 16:30_: Breakout Sessions (choose one):
+- _15:30 - 16:30_: Breakout Sessions:
   - **Discussion: Autonomous Systems for Science**
   - **Discussion: Building Scientific Foundation Models**
   - **Discussion: Panel on Biomedical Discovery** (Room CUC Dowd)

--- a/pages/schedule.mdx
+++ b/pages/schedule.mdx
@@ -10,6 +10,17 @@ Location: [Room CUC-MPW, Cohon University Center](https://www.cmu.edu/cohon-univ
 - _11:45 - 13:00_: Lunch + Poster Session
 - _13:00 - 13:45_: Invited Talk - Akari Asai (CMU)
 - _13:45 - 14:30_: Invited Talk - Keyon Vafa (Harvard)
-- _14:30 - 16:00_: Breakout Session (Lab Visit, Hands-on Sessions on Research Automation, AI Surveys, etc.)
-- _16:00 - 17:00_: Group Discussion and Closing
+- _14:30 - 15:30_: Breakout Session (Lab Visit, Hands-on Sessions on Research Automation, AI Surveys, etc.)
+- _15:30 - 16:30_: Panel Discussion - "How would Generative AI and Automatic Agents accelerate Biomedical Discovery?" (Room CUC Dowd)
+- _16:30 - 17:00_: Group Discussion and Closing
 
+## Panel Discussion Details
+
+### How would Generative AI and Automatic Agents accelerate Biomedical Discovery?
+
+**Time:** Friday, September 12, 3:30-4:30pm (15:30-16:30)  
+**Location:** CUC Dowd Room  
+**Panelists:** 
+- Lei Li
+- Martin Zhang
+- TBD other panelists

--- a/pages/schedule.mdx
+++ b/pages/schedule.mdx
@@ -10,14 +10,17 @@ Location: [Room CUC-MPW, Cohon University Center](https://www.cmu.edu/cohon-univ
 - _11:45 - 13:00_: Lunch + Poster Session
 - _13:00 - 13:45_: Invited Talk - Akari Asai (CMU)
 - _13:45 - 14:30_: Invited Talk - Keyon Vafa (Harvard)
-- _14:30 - 15:30_: Breakout Session (Lab Visit, Hands-on Sessions on Research Automation, AI Surveys, etc.)
-- _15:30 - 16:30_: Panel Discussion - "How would Generative AI and Automatic Agents accelerate Biomedical Discovery?" (Room CUC Dowd)
+- _15:30 - 16:30_: Breakout Sessions (choose one):
+  - **Discussion: Autonomous Systems for Science**
+  - **Discussion: Building Scientific Foundation Models**
+  - **Discussion: Panel on Biomedical Discovery** (Room CUC Dowd)
+  - **Hands-on: Visit an Autonomous Lab**
 - _16:30 - 17:00_: Group Discussion and Closing
 
-## Panel Discussion Details
+## Breakout Session Details
 
-### How would Generative AI and Automatic Agents accelerate Biomedical Discovery?
-
+### Discussion: Panel on Biomedical Discovery
+**Topic:** "How would Generative AI and Automatic Agents accelerate Biomedical Discovery?"  
 **Time:** Friday, September 12, 3:30-4:30pm (15:30-16:30)  
 **Location:** CUC Dowd Room  
 **Panelists:** 


### PR DESCRIPTION
This PR adds the biomedical discovery panel information to the workshop schedule as requested.

## Changes Made:
- Added panel "How would Generative AI and Automatic Agents accelerate Biomedical Discovery?"
- **Panelists:** Lei Li, Martin Zhang, and TBD other panelists
- **Location:** CUC Dowd Room
- **Time:** Friday, September 12, 3:30-4:30pm (15:30-16:30)

## Schedule Structure:
- Other breakout sessions run for 2 hours (14:30-16:30): Autonomous Systems, Foundation Models, Lab Visit
- Panel runs for 1 hour (15:30-16:30) in CUC Dowd Room
- Added detailed panel information section below main schedule

## Context:
Based on Slack conversation indicating 105 signups, need for breakout session planning, and specific request to add panel details to the website schedule.

@nightingal3 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/68976599a8bf44c8a8a919bb6cbea982)