### PR TITLE
Update Autonomous Systems for Science workshop time to 3-4pm

### DIFF
--- a/pages/schedule.mdx
+++ b/pages/schedule.mdx
@@ -11,7 +11,7 @@ Location: [Room CUC-MPW, Cohon University Center](https://www.cmu.edu/cohon-univ
 - _13:00 - 13:45_: Invited Talk - Akari Asai (CMU)
 - _13:45 - 14:30_: Invited Talk - Keyon Vafa (Harvard)
 - _14:30 - 16:30_: Breakout Sessions:
-  - **Discussion: Autonomous Systems for Science**
+  - **Discussion: Autonomous Systems for Science** (3:00-4:00pm)
   - **Discussion: Building Scientific Foundation Models**
   - **Hands-on: Visit an Autonomous Lab**
 - _15:30 - 16:30_: **Discussion: Panel on Biomedical Discovery** (Room CUC Dowd)


### PR DESCRIPTION
This PR updates the schedule page to specify that the "Discussion: Autonomous Systems for Science" workshop will run from 3:00-4:00pm during the breakout sessions.

**Changes:**
- Added specific time "(3:00-4:00pm)" to the Autonomous Systems for Science workshop entry in the schedule

This addresses the request to update the workshop time to 3-4pm instead of the general breakout session timeframe.

@nightingal3 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/32c553e800b148c6a15fe781d6bbeaeb)