### PR TITLE
Add CMU Cloud Lab visit details to breakout session

### DIFF
--- a/pages/schedule.mdx
+++ b/pages/schedule.mdx
@@ -13,11 +13,18 @@ Location: [Room CUC-MPW, Cohon University Center](https://www.cmu.edu/cohon-univ
 - _14:30 - 16:30_: Breakout Sessions:
   - **Discussion: Autonomous Systems for Science** (3:00-4:00pm)
   - **Discussion: Building Scientific Foundation Models**
-  - **Hands-on: Visit an Autonomous Lab**
+  - **Hands-on: CMU Cloud Lab Visit** (3:00-4:00pm)
 - _15:30 - 16:30_: **Discussion: Panel on Biomedical Discovery** (Room CUC Dowd)
 - _16:30 - 17:00_: Group Discussion and Closing
 
 ## Breakout Session Details
+
+### Hands-on: CMU Cloud Lab Visit
+**Time:** Friday, September 12, 3:00-4:00pm (15:00-16:00)  
+**Meeting Location:** [Cloud Lab Parking Lot](https://maps.app.goo.gl/ZXs3ZtfMydAKhFsN8) at 3:00pm  
+**Transportation:** Please share an Uber/Lyft to arrive on time  
+
+Join us for an exclusive tour of CMU's revolutionary Cloud Lab - the first academic cloud laboratory that brings remote science into the mainstream. Learn more about this groundbreaking facility: [CMU Cloud Lab Article](https://the-tartan.org/2024/02/19/cmu-cloud-lab-to-bring-remote-science-into-mainstream/)
 
 ### Discussion: Panel on Biomedical Discovery
 **Topic:** "How would Generative AI and Automatic Agents accelerate Biomedical Discovery?"  

--- a/pages/schedule.mdx
+++ b/pages/schedule.mdx
@@ -24,7 +24,7 @@ Location: [Room CUC-MPW, Cohon University Center](https://www.cmu.edu/cohon-univ
 **Meeting Location:** [Cloud Lab Parking Lot](https://maps.app.goo.gl/ZXs3ZtfMydAKhFsN8) at 3:00pm  
 **Transportation:** Please share an Uber/Lyft to arrive on time  
 
-Join us for an exclusive tour of CMU's revolutionary Cloud Lab - the first academic cloud laboratory that brings remote science into the mainstream. Learn more about this groundbreaking facility: [CMU Cloud Lab Article](https://the-tartan.org/2024/02/19/cmu-cloud-lab-to-bring-remote-science-into-mainstream/)
+Join us for a tour of CMU's Cloud Lab - an academic cloud laboratory for remote science research. Learn more about this facility: [CMU Cloud Lab Article](https://the-tartan.org/2024/02/19/cmu-cloud-lab-to-bring-remote-science-into-mainstream/)
 
 ### Discussion: Panel on Biomedical Discovery
 **Topic:** "How would Generative AI and Automatic Agents accelerate Biomedical Discovery?"  

--- a/pages/schedule.mdx
+++ b/pages/schedule.mdx
@@ -14,7 +14,7 @@ Location: [Room CUC-MPW, Cohon University Center](https://www.cmu.edu/cohon-univ
   - **Discussion: Autonomous Systems for Science** (3:00-4:00pm)
   - **Discussion: Building Scientific Foundation Models**
   - **Hands-on: CMU Cloud Lab Visit** (3:00-4:00pm)
-- _15:30 - 16:30_: **Discussion: Panel on Biomedical Discovery** (Room CUC Dowd)
+  - **Discussion: Panel on Biomedical Discovery** (3:30-4:30pm, Room CUC Dowd)
 - _16:30 - 17:00_: Group Discussion and Closing
 
 ## Breakout Session Details


### PR DESCRIPTION
This PR adds detailed information for the CMU Cloud Lab visit breakout session:

## Changes Made:
- Updated breakout session title from "Hands-on: Visit an Autonomous Lab" to "Hands-on: CMU Cloud Lab Visit (3:00-4:00pm)"
- Added comprehensive breakout session details including:
  - **Time**: Friday, September 12, 3:00-4:00pm
  - **Meeting Location**: Direct link to Cloud Lab parking lot on Google Maps
  - **Transportation**: Instructions to share Uber/Lyft for timely arrival
  - **Description**: Information about the Cloud Lab tour with link to The Tartan article explaining the facility

## Links Added:
- [Cloud Lab Parking Lot Location](https://maps.app.goo.gl/ZXs3ZtfMydAKhFsN8)
- [CMU Cloud Lab Article](https://the-tartan.org/2024/02/19/cmu-cloud-lab-to-bring-remote-science-into-mainstream/)

This provides participants with all the necessary information to join the Cloud Lab visit, including where to meet and how to get there.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c238fed20f4f45c39e47fe834797535e)