### PR TITLE
Add best poster voting link to poster session page

### DIFF
--- a/pages/posters.mdx
+++ b/pages/posters.mdx
@@ -13,6 +13,10 @@ We invite researchers to submit posters related to AI for Science. This is a gre
 - Include title, authors, affiliations, and a brief description of your work
 - Use the [poster submission form](https://forms.gle/VYeiDQ4URbRqecQj8) to submit your poster
 
+### Best Poster Award
+
+**[Vote for the best poster here!](https://docs.google.com/forms/d/e/1FAIpQLSdhlHQe5nFYL-jwJxeLVGfpZrAkA8heNn23ALDqMUOEylYnMA/viewform?usp=dialog)**
+
 ### Topics of Interest
 
 - AI for scientific discovery and hypothesis generation


### PR DESCRIPTION
This PR adds the voting link for the best poster award to the poster session page.

## Changes Made
- Added a new "Best Poster Award" section to `pages/posters.mdx`
- Included the Google Forms voting link with prominent formatting
- Positioned the voting section between submission guidelines and topics of interest for optimal visibility

## Link Added
https://docs.google.com/forms/d/e/1FAIpQLSdhlHQe5nFYL-jwJxeLVGfpZrAkA8heNn23ALDqMUOEylYnMA/viewform?usp=dialog

This makes it easy for workshop attendees to find and vote for their favorite poster during the poster session.

@nightingal3 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f864b16578114f2e98cb96f194e86de1)